### PR TITLE
Fix UTF-8 surrogate crashes in AI analysis

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -665,7 +665,7 @@ uv run python scripts/generate_third_party_notices.py
 | `pify` | `2.3.0` | MIT | — |
 | `pirates` | `4.0.7` | MIT | — |
 | `possible-typed-array-names` | `1.1.0` | MIT | — |
-| `postcss` | `8.5.21` | MIT | — |
+| `postcss` | `8.5.23` | MIT | — |
 | `postcss-import` | `15.1.0` | MIT | — |
 | `postcss-js` | `4.1.0` | MIT | — |
 | `postcss-load-config` | `6.0.1` | MIT | — |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,7 +32,7 @@
         "eslint": "^9.17.0",
         "eslint-config-next": "15.5.21",
         "jsdom": "29.1.1",
-        "postcss": "8.5.21",
+        "postcss": "8.5.23",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.7.2",
         "vitest": "4.1.10"
@@ -7508,9 +7508,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
-      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "eslint": "^9.17.0",
     "eslint-config-next": "15.5.21",
     "jsdom": "29.1.1",
-    "postcss": "8.5.21",
+    "postcss": "8.5.23",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
     "vitest": "4.1.10"

--- a/frontend/server/resolve_instrument.py
+++ b/frontend/server/resolve_instrument.py
@@ -13,6 +13,7 @@ import yfinance as yf
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from tradingagents.dataflows.symbol_utils import normalize_symbol
+from tradingagents.llm_clients.base_client import normalize_utf8_text
 from tradingagents.llm_clients.factory import create_llm_client
 
 CRYPTO_BASES = {"BTC", "ETH", "SOL", "XRP", "ADA", "DOGE", "LTC", "BCH", "DOT", "AVAX", "LINK"}
@@ -44,7 +45,8 @@ COMMON_NAME_ALIASES = {
 
 
 def emit(value: Dict[str, Any]) -> None:
-    print(json.dumps(value, ensure_ascii=False, default=str), flush=True)
+    serialized = json.dumps(value, ensure_ascii=False, default=str)
+    print(normalize_utf8_text(serialized), flush=True)
 
 
 def normalize_query_ticker(query: str) -> str:

--- a/frontend/server/run_analysis.py
+++ b/frontend/server/run_analysis.py
@@ -25,6 +25,7 @@ from tradingagents.graph.analyst_execution import (
 )
 from tradingagents.graph.checkpointer import clear_checkpoint, thread_id
 from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.llm_clients.base_client import normalize_utf8_text
 
 REPORT_SECTION_KEYS = [
     "market_report",
@@ -39,7 +40,8 @@ REPORT_SECTION_KEYS = [
 
 def emit(event: Dict[str, Any]) -> None:
     event.setdefault("timestamp", datetime.now().strftime("%H:%M:%S"))
-    print(json.dumps(event, ensure_ascii=False, default=str), flush=True)
+    serialized = json.dumps(event, ensure_ascii=False, default=str)
+    print(normalize_utf8_text(serialized), flush=True)
 
 
 def normalize_analysts(raw: Iterable[str], asset_type: str) -> List[str]:
@@ -544,7 +546,9 @@ def main() -> int:
             symbol = str(payload.get("symbol") or "")
             curr_date = str(payload.get("currDate") or payload.get("curr_date") or "")
             print(
-                json.dumps(load_chart(symbol, curr_date), ensure_ascii=False, allow_nan=False),
+                normalize_utf8_text(
+                    json.dumps(load_chart(symbol, curr_date), ensure_ascii=False, allow_nan=False)
+                ),
                 flush=True,
             )
             return 0
@@ -552,7 +556,9 @@ def main() -> int:
             from test_llm import test_connection
 
             print(
-                json.dumps(test_connection(payload), ensure_ascii=False, allow_nan=False),
+                normalize_utf8_text(
+                    json.dumps(test_connection(payload), ensure_ascii=False, allow_nan=False)
+                ),
                 flush=True,
             )
             return 0

--- a/tests/test_deepseek_reasoning.py
+++ b/tests/test_deepseek_reasoning.py
@@ -241,7 +241,19 @@ class TestBaseClassIsolation:
     def test_normalized_does_not_propagate_reasoning_content(self):
         """The general-purpose NormalizedChatOpenAI must not carry
         DeepSeek-specific behaviour. Only the subclass does."""
-        assert not hasattr(NormalizedChatOpenAI, "_get_request_payload") or (
-            NormalizedChatOpenAI._get_request_payload
-            is NormalizedChatOpenAI.__bases__[0]._get_request_payload
+        client = NormalizedChatOpenAI(
+            model="generic-openai-compatible",
+            api_key="placeholder",
+            base_url="https://example.test/v1",
         )
+        prior = AIMessage(
+            content="Plan",
+            additional_kwargs={"reasoning_content": "DeepSeek-only state"},
+        )
+
+        payload = client._get_request_payload([prior, HumanMessage(content="Refine.")])
+
+        assistant = next(
+            message for message in payload["messages"] if message["role"] == "assistant"
+        )
+        assert "reasoning_content" not in assistant

--- a/tests/test_utf8_safety.py
+++ b/tests/test_utf8_safety.py
@@ -1,0 +1,121 @@
+import io
+import json
+from contextlib import redirect_stdout
+
+import httpx
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from frontend.server.run_analysis import emit
+from tradingagents.llm_clients.base_client import (
+    normalize_content,
+    normalize_utf8_payload,
+    normalize_utf8_text,
+)
+from tradingagents.llm_clients.openai_client import DeepSeekChatOpenAI
+
+
+@pytest.mark.unit
+def test_normalize_utf8_text_repairs_only_malformed_surrogates():
+    value = "中文🙂 pair:\ud83d\ude00 low:\udcad high:\ud800"
+
+    normalized = normalize_utf8_text(value)
+
+    assert normalized == "中文🙂 pair:😀 low:� high:�"
+    assert normalized.encode("utf-8").decode("utf-8") == normalized
+
+
+@pytest.mark.unit
+def test_normalize_utf8_payload_repairs_nested_json_values_and_keys():
+    payload = {
+        "outer\udcad": ["ok", {"nested": "bad\ud800"}],
+        "tuple": ("pair\ud83d\ude00",),
+    }
+
+    normalized = normalize_utf8_payload(payload)
+
+    assert normalized == {
+        "outer�": ["ok", {"nested": "bad�"}],
+        "tuple": ("pair😀",),
+    }
+    json.dumps(normalized, ensure_ascii=False).encode("utf-8")
+
+
+@pytest.mark.unit
+def test_normalize_content_repairs_provider_text_before_graph_state():
+    response = AIMessage(
+        content="answer\udcad",
+        additional_kwargs={"reasoning_content": "reason\ud800"},
+    )
+
+    normalized = normalize_content(response)
+
+    assert normalized.content == "answer�"
+    assert normalized.additional_kwargs["reasoning_content"] == "reason�"
+
+
+@pytest.mark.unit
+def test_deepseek_request_replaces_surrogates_before_sdk_utf8_encoding():
+    requests = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content.decode("utf-8")))
+        response_payload = {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "deepseek-chat",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "ok",
+                        "reasoning_content": "server reasoning\udcad",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+        return httpx.Response(
+            200,
+            content=json.dumps(response_payload).encode("utf-8"),
+            headers={"content-type": "application/json"},
+        )
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handle))
+    client = DeepSeekChatOpenAI(
+        model="deepseek-chat",
+        api_key="placeholder",
+        base_url="https://api.deepseek.test",
+        http_client=http_client,
+    )
+    prior = AIMessage(
+        content="previous",
+        additional_kwargs={"reasoning_content": "reason\udcad"},
+    )
+
+    response = client.invoke(
+        [prior, HumanMessage(content="中文🙂 pair \ud83d\ude00 malformed \udcad")]
+    )
+    http_client.close()
+
+    assert response.content == "ok"
+    assert response.additional_kwargs["reasoning_content"] == "server reasoning�"
+    assert len(requests) == 1
+    assert requests[0]["messages"][0]["reasoning_content"] == "reason�"
+    assert requests[0]["messages"][1]["content"] == "中文🙂 pair 😀 malformed �"
+
+
+@pytest.mark.unit
+def test_runner_emit_writes_strict_utf8_for_malformed_event_text():
+    raw_output = io.BytesIO()
+    strict_stdout = io.TextIOWrapper(raw_output, encoding="utf-8", errors="strict")
+
+    with redirect_stdout(strict_stdout):
+        emit({"type": "message", "message": "market data\udcad"})
+    strict_stdout.flush()
+
+    event = json.loads(raw_output.getvalue().decode("utf-8"))
+    assert event["message"] == "market data�"

--- a/tradingagents/llm_clients/base_client.py
+++ b/tradingagents/llm_clients/base_client.py
@@ -1,15 +1,63 @@
+import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Optional
-import warnings
+
+
+def normalize_utf8_text(value: str) -> str:
+    """Return text that can be encoded as strict UTF-8.
+
+    Python strings can contain isolated UTF-16 surrogate code points when an
+    upstream API returns malformed escaped Unicode.  UTF-8 encoders reject
+    those code points.  Preserve valid surrogate pairs by combining them into
+    their Unicode scalar value and replace only malformed surrogates with the
+    standard replacement character.
+    """
+    if not any(0xD800 <= ord(char) <= 0xDFFF for char in value):
+        return value
+
+    normalized = []
+    index = 0
+    while index < len(value):
+        codepoint = ord(value[index])
+        if 0xD800 <= codepoint <= 0xDBFF and index + 1 < len(value):
+            low = ord(value[index + 1])
+            if 0xDC00 <= low <= 0xDFFF:
+                normalized.append(chr(0x10000 + ((codepoint - 0xD800) << 10) + (low - 0xDC00)))
+                index += 2
+                continue
+        if 0xD800 <= codepoint <= 0xDFFF:
+            normalized.append("\ufffd")
+        else:
+            normalized.append(value[index])
+        index += 1
+
+    return "".join(normalized)
+
+
+def normalize_utf8_payload(value: Any) -> Any:
+    """Recursively make JSON-like payload strings safe for UTF-8 encoding."""
+    if isinstance(value, str):
+        return normalize_utf8_text(value)
+    if isinstance(value, dict):
+        return {
+            normalize_utf8_payload(key): normalize_utf8_payload(item) for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [normalize_utf8_payload(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(normalize_utf8_payload(item) for item in value)
+    return value
 
 
 def normalize_content(response):
-    """Normalize LLM response content to a plain string.
+    """Normalize LLM response content to valid-Unicode plain text.
 
     Multiple providers (OpenAI Responses API, Google Gemini 3) return content
     as a list of typed blocks, e.g. [{'type': 'reasoning', ...}, {'type': 'text', 'text': '...'}].
     Downstream agents expect response.content to be a string. This extracts
-    and joins the text blocks, discarding reasoning/metadata blocks.
+    and joins the text blocks, discarding reasoning/metadata blocks. It also
+    repairs malformed surrogate code points in provider text and metadata
+    before they enter graph state or persistence.
     """
     content = response.content
     if isinstance(content, list):
@@ -22,6 +70,10 @@ def normalize_content(response):
             for item in content
         ]
         response.content = "\n".join(t for t in texts if t)
+    if isinstance(response.content, str):
+        response.content = normalize_utf8_text(response.content)
+    if isinstance(getattr(response, "additional_kwargs", None), dict):
+        response.additional_kwargs = normalize_utf8_payload(response.additional_kwargs)
     return response
 
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -7,7 +7,7 @@ from langchain_openai import ChatOpenAI
 from openai import APIConnectionError, APITimeoutError, InternalServerError, RateLimitError
 
 from .api_key_env import get_api_key_env
-from .base_client import BaseLLMClient, normalize_content
+from .base_client import BaseLLMClient, normalize_content, normalize_utf8_payload
 from .capabilities import get_capabilities
 from .validators import validate_model
 
@@ -41,6 +41,10 @@ class NormalizedChatOpenAI(ChatOpenAI):
                 if attempt >= max_attempts - 1:
                     raise
                 time.sleep(base_delay * (2**attempt))
+
+    def _get_request_payload(self, input_, *, stop=None, **kwargs):
+        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+        return normalize_utf8_payload(payload)
 
     def with_structured_output(self, schema, *, method=None, **kwargs):
         caps = get_capabilities(self.model_name)
@@ -99,7 +103,7 @@ class DeepSeekChatOpenAI(NormalizedChatOpenAI):
             reasoning = message.additional_kwargs.get("reasoning_content")
             if reasoning is not None:
                 message_dict["reasoning_content"] = reasoning
-        return payload
+        return normalize_utf8_payload(payload)
 
     def _create_chat_result(self, response, generation_info=None):
         chat_result = super()._create_chat_result(response, generation_info)


### PR DESCRIPTION
Fixes #45

## What changed

- Normalize malformed lone UTF-16 surrogate code points to U+FFFD while preserving valid Unicode and surrogate pairs.
- Sanitize OpenAI-compatible request payloads before SDK JSON encoding, including a second pass after DeepSeek reattaches `reasoning_content`.
- Normalize provider response content/metadata before it enters graph state or persistence.
- Protect analysis-runner and instrument-resolver JSONL output from the same strict UTF-8 encoding failure.
- Add regression coverage for nested payloads, DeepSeek multi-turn reasoning, valid emoji/CJK text, and strict runner stdout.

## Root cause

DeepSeek's connection test is single-turn, but analyst execution is multi-turn. A lone surrogate such as `\udcad` can be accepted by Python/LangChain in provider `reasoning_content` or external data, then reattached to the next OpenAI-compatible request. The SDK serializes JSON with `ensure_ascii=False` and encodes it as strict UTF-8, which raises `UnicodeEncodeError: surrogates not allowed`. The runner's JSONL output had the same failure mode.

## Impact

Analysis continues when upstream provider or market-data text contains malformed escaped Unicode. Only invalid surrogate code points are replaced; normal Chinese text, emoji, and valid surrogate pairs are preserved.

## Validation

- `python -m pytest -q`: 334 passed, 1 skipped, 75 subtests passed
- `ruff check .`
- `ruff format --check .`
- `git diff --check`
